### PR TITLE
Changes that Clippy told me to make

### DIFF
--- a/pax/src/main.rs
+++ b/pax/src/main.rs
@@ -480,7 +480,7 @@ impl Vlq {
             l += 1;
         }
         self.buf[l] = B64[y];
-        str::from_utf8(&self.buf[0..l + 1]).unwrap()
+        str::from_utf8(&self.buf[0..=l]).unwrap()
     }
 }
 const B64: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/pax/src/main.rs
+++ b/pax/src/main.rs
@@ -237,7 +237,7 @@ impl<'a, 'b> Writer<'a, 'b> {
     fn write_map_to<W: io::Write>(&self, w: &mut W) -> serde_json::Result<()> {
         // https://sourcemaps.info/spec.html
 
-        let ref modules = self.sorted_modules();
+        let modules = &self.sorted_modules();
         let dir = self.entry_point.parent().unwrap();
 
         #[derive(Serialize, Debug)]

--- a/pax/src/main.rs
+++ b/pax/src/main.rs
@@ -218,9 +218,9 @@ impl<'a, 'b> Writer<'a, 'b> {
             SourceMapOutput::Inline => {
                 let mut map = Vec::new();
                 self.write_map_to(&mut map)?;
-                write!(
+                writeln!(
                     w,
-                    "//# sourceMappingURL=data:application/json;charset=utf-8;base64,{data}\n",
+                    "//# sourceMappingURL=data:application/json;charset=utf-8;base64,{data}",
                     data = base64::encode(&map),
                 )?;
             }
@@ -228,7 +228,7 @@ impl<'a, 'b> Writer<'a, 'b> {
                 // TODO handle error
                 let relative = path.relative_from(output_file.parent().unwrap());
                 let map = relative.as_ref().unwrap_or(path);
-                write!(w, "//# sourceMappingURL={map}\n", map = map.display(),)?;
+                writeln!(w, "//# sourceMappingURL={map}", map = map.display(),)?;
             }
         }
         Ok(())
@@ -989,7 +989,7 @@ fn write_help(f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "\n\n")?;
     write_usage(f)?;
     write!(f, "\n\n")?;
-    write!(
+    writeln!(
         f,
         "\
 Options:
@@ -1052,8 +1052,7 @@ Options:
         Print this message.
 
     -v, --version
-        Print version information.
-"
+        Print version information."
     )
 }
 


### PR DESCRIPTION
- use writeln instead of write when we want a new line after the write
- `ref` on an entire `let` pattern is discouraged, let's take a reference with `&` instead
- Use the inclusive range operator as it is easier to read