### PR TITLE
Remove nightly builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        rust: [stable, beta, nightly]
+        rust: [stable, beta]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
We will keep beta, so we know if anything is coming up that will
break our builds in the future, but we won't build on nightly
because it could break every day.

also adds a newline