### PR TITLE
copy the file instead of symlink as users can get error 'too many levels of symbolic links'

### DIFF
--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -17,4 +17,4 @@ if (process.platform === "win32" && process.arch === "x64") {
 const oaxDestination = path.join(__dirname, './oax');
 
 fs.unlinkSync(oaxDestination);
-fs.symlinkSync(pathToOaxBinary, oaxDestination);
+fs.copyFileSync(pathToOaxBinary, oaxDestination);


### PR DESCRIPTION
We see this error on os-x for the origami-build-service