### PR TITLE
Remove global parameter to the bundle as it is not used.

### DIFF
--- a/src/javascript/head.js
+++ b/src/javascript/head.js
@@ -1,4 +1,4 @@
-(function(global) {
+(function() {
   const Pax = {}
   Pax.baseRequire = typeof require !== "undefined" ? require : n => {
     throw new Error(`Could not resolve module name: ${n}`)

--- a/src/javascript/tail.js
+++ b/src/javascript/tail.js
@@ -1,1 +1,1 @@
-})(typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : this)
+})()


### PR DESCRIPTION
 If code needs the global, it should use `globalThis`/`window`/`self`.

Resolves #16 