### PR TITLE
Make npm ci work for oax and it's platform-specific packages

### DIFF
--- a/npm/oax-darwin/package.json
+++ b/npm/oax-darwin/package.json
@@ -9,5 +9,8 @@
   },
   "os": [
     "darwin"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/npm/oax-darwin/postinstall.js
+++ b/npm/oax-darwin/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}

--- a/npm/oax-linux-64/package.json
+++ b/npm/oax-linux-64/package.json
@@ -8,5 +8,8 @@
     "oax": "oax"
   },
   "os" : [ "linux" ],
-  "cpu" : [ "x64" ]
+  "cpu" : [ "x64" ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/npm/oax-linux-64/postinstall.js
+++ b/npm/oax-linux-64/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}

--- a/npm/oax-windows-64/package.json
+++ b/npm/oax-windows-64/package.json
@@ -8,5 +8,8 @@
     "oax": "oax"
   },
   "os" : [ "win32" ],
-  "cpu" : [ "x64" ]
+  "cpu" : [ "x64" ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/npm/oax-windows-64/postinstall.js
+++ b/npm/oax-windows-64/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}


### PR DESCRIPTION
Adds postinstall scripts which throw an error if the os or cpu is different to what the package supports.

This is a required for npm ci to work. npm/cli#558