### PR TITLE
Revert "use .bower.json manifest instead of bower.json manifest"

### DIFF
--- a/src/input_options.rs
+++ b/src/input_options.rs
@@ -16,7 +16,7 @@ impl PackageManager {
 
     pub fn file(&self) -> &'static str {
         match self {
-            Self::Bower => ".bower.json",
+            Self::Bower => "bower.json",
             Self::Npm => "package.json",
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,7 +371,7 @@ Options:
         as require('<module>') references in the bundle.
 
     -b, --for-bower
-        Use .bower.json instead of package.json
+        Use bower.json instead of package.json
 
     -h, --help
         Print this message.


### PR DESCRIPTION
Reverts Financial-Times/oax#30

This PR has broken building for me of every component, it never finds the root of the package.

```
oax: main module '/home/chee/projects/origami/components/footer' not found
```