### PR TITLE
Scope subpackages under @financial-times/

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Cargo
+name: Publish package and subpackages to npm and github
 
 on:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
         cd npm/${{ matrix.npm-name }}/
         ref='${{github.ref}}'
         npm version ${ref#refs/tags/}
-        npm publish
+        npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Publish meta-package to npm
@@ -82,7 +82,7 @@ jobs:
         then
           npx npm-check-updates -u
           npm update
-          npm publish
+          npm publish --access public
         fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/npm/index.js
+++ b/npm/index.js
@@ -2,13 +2,13 @@
 
 module.exports = (function(){
   try {
-    return require('scrumple-windows-64');
+    return require('@financial-times/scrumple-linux-64');
   } catch {
     try {
-      return require('scrumple-darwin');
+      return require('@financial-times/scrumple-darwin');
     } catch {
       try {
-        return require('scrumple-linux-64');
+        return require('@financial-times/scrumple-windows-64');
       } catch {
         throw new Error('scrumple does not have a precompiled binary for the platform/architecture you are using. Please contact Origami or open an issue on https://github.com/Financial-Times/scrumple/issues');
       }

--- a/npm/package.json
+++ b/npm/package.json
@@ -6,9 +6,9 @@
   "repository": "Financial-times/scrumple",
   "bin": "scrumple",
   "optionalDependencies": {
-    "scrumple-darwin": "*",
-    "scrumple-linux-64": "*",
-    "scrumple-windows-64": "*"
+    "@financial-times/scrumple-darwin": "*",
+    "@financial-times/scrumple-linux-64": "*",
+    "@financial-times/scrumple-windows-64": "*"
   },
   "scripts": {
     "postinstall": "node ./postinstall.js"

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -5,11 +5,11 @@ const path = require('path');
 
 let pathToScrumpleBinary;
 if (process.platform === "win32" && process.arch === "x64") {
-    pathToScrumpleBinary = require('scrumple-windows-64');
+    pathToScrumpleBinary = require('@financial-times/scrumple-windows-64');
 } else if (process.platform === "darwin") {
-    pathToScrumpleBinary = require('scrumple-darwin');
+    pathToScrumpleBinary = require('@financial-times/scrumple-darwin');
 } else if (process.platform === "linux" && process.arch === "x64") {
-    pathToScrumpleBinary = require('scrumple-linux-64');
+    pathToScrumpleBinary = require('@financial-times/scrumple-linux-64');
 } else {
     throw new Error('scrumple does not have a precompiled binary for the platform/architecture you are using. Please contact Origami or open an issue on https://github.com/Financial-Times/scrumple/issues');
 }

--- a/npm/scrumple-darwin/package-lock.json
+++ b/npm/scrumple-darwin/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrumple-darwin",
+  "name": "@financial-times/scrumple-darwin",
   "version": "0.0.0",
   "lockfileVersion": 1
 }

--- a/npm/scrumple-darwin/package.json
+++ b/npm/scrumple-darwin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrumple-darwin",
+  "name": "@financial-times/scrumple-darwin",
   "version": "0.0.0",
   "description": "Pre-compiled scrumple binary for darwin/osx - fast bundler for JavaScript projects",
   "license": "MIT",

--- a/npm/scrumple-linux-64/package-lock.json
+++ b/npm/scrumple-linux-64/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrumple-linux-64",
+  "name": "@financial-times/scrumple-linux-64",
   "version": "0.0.0",
   "lockfileVersion": 1
 }

--- a/npm/scrumple-linux-64/package.json
+++ b/npm/scrumple-linux-64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrumple-linux-64",
+  "name": "@financial-times/scrumple-linux-64",
   "version": "1.0.0",
   "description": "Pre-compiled scrumple binary for 64-bit linux - fast bundler for JavaScript projects",
   "license": "MIT",

--- a/npm/scrumple-windows-64/package-lock.json
+++ b/npm/scrumple-windows-64/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrumple-windows-64",
+  "name": "@financial-times/scrumple-windows-64",
   "version": "0.0.0",
   "lockfileVersion": 1
 }

--- a/npm/scrumple-windows-64/package.json
+++ b/npm/scrumple-windows-64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scrumple-windows-64",
+  "name": "@financial-times/scrumple-windows-64",
   "version": "0.0.0",
   "description": "Pre-compiled scrumple binary for 64-bit windows - fast bundler for JavaScript projects",
   "license": "MIT",


### PR DESCRIPTION
npm's spam detection filter blocked the package name `scrumple-linux-64`.
npm have not responded to my email.
how about this instead?