### PR TITLE
Allow npm dev deps when -N is passed

### DIFF
--- a/src/input_options.rs
+++ b/src/input_options.rs
@@ -33,4 +33,5 @@ impl Default for PackageManager {
 pub struct InputOptions {
     pub package_manager: PackageManager,
     pub external: FnvHashSet<String>,
+    pub forced_npm_deps: FnvHashSet<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,11 +104,19 @@ fn find_node_module(path: &PathBuf, name: &str) -> Option<PathBuf> {
     loop {
         nm.push("node_modules");
         nm.push(name);
+
+        // One pop per folder
+        let mut pops = 1 + name.split("/").count();
+
         if nm.exists() {
             return Some(nm);
         }
-        nm.pop();
-        nm.pop();
+
+        while pops > 0 {
+            nm.pop();
+            pops -= 1
+        }
+
         if !nm.pop() {
             return None;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -455,7 +455,8 @@ Options:
     -b, --for-bower
         Use bower.json instead of package.json
 
-   -N, --allow-npm-dev-deps <module1,module2,...> When using --for-bower, this
+   -N, --allow-npm-dev-deps
+   When using --for-bower, this
         forces packages in the project's package.json#devDependencies to be
         resolved through npm. This is is for creating testing bundles that use
         npm-only dependencies

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -451,6 +451,7 @@ mod test {
                 main: PathBuf::from("./index"),
                 browser_substitutions: BrowserSubstitutionMap(map! {
                     PathBuf::from(".") => BrowserSubstitution::Replace(PathBuf::from("./simple")),
+                    PathBuf::from("./index") => BrowserSubstitution::Replace(PathBuf::from("./simple")),
                 }),
             }
         );

--- a/src/resolver/test.rs
+++ b/src/resolver/test.rs
@@ -33,14 +33,26 @@ fn test_resolve_path_or_module() {
         // resolves with an empty cache...
         assert_eq!(
             resolver
-                .resolve_path_or_module(None, from_path.clone(), false, false)
+                .resolve_path_or_module(
+                    None,
+                    from_path.clone(),
+                    false,
+                    false,
+                    InputOptions::default().package_manager
+                )
                 .unwrap(),
             expected
         );
         // ...and with everything cached
         assert_eq!(
             resolver
-                .resolve_path_or_module(None, from_path, false, false)
+                .resolve_path_or_module(
+                    None,
+                    from_path,
+                    false,
+                    false,
+                    InputOptions::default().package_manager
+                )
                 .unwrap(),
             expected
         );
@@ -218,6 +230,7 @@ fn assert_resolves_bower(context: &str, from: &str, to: Option<&str>) {
     let input_options = InputOptions {
         package_manager: PackageManager::Bower,
         external,
+        forced_npm_deps: FnvHashSet::default(),
     };
     assert_resolves_with_options(context, from, to, Some(&input_options));
 }
@@ -2176,10 +2189,12 @@ fn test_external() {
         external: vec!["external".to_owned(), "external-only-module".to_owned()]
             .into_iter()
             .collect(),
+        forced_npm_deps: FnvHashSet::default(),
     };
     let non = InputOptions {
         package_manager: PackageManager::Npm,
         external: Default::default(),
+        forced_npm_deps: FnvHashSet::default(),
     };
 
     let ctx = "resolve/hypothetical.js";


### PR DESCRIPTION
`scrumple --for-bower --allow-npm-dev-deps` will make all dependencies of the projects devDependencies resolve through npm. this is for use in tests.

this could be confusing for a number of reasons:
1. the tested bundle will be different than the bundle that is published.
2. if there is a bower dependency with the same name as an npm dependency, and the bower dependency is in use by the package and the npm dependency is used by any of the testing dependencies (or their dependencies) then the bundle will use the npm dependency for both. that will be confusing to debug.

--

so far i've been trying it out with latest `o-comments` as mentioned in the issue this resolves #46. `obt test` no longer fails to work, out but some of the tests do not pass.

more work will be needed