### PR TITLE
Fix help

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Options:
     -b, --for-bower
         Use bower.json instead of package.json
 
+    -N, --allow-npm-dev-deps
+        When using --for-bower, this forces packages in the project's
+        package.json#devDependencies to be resolved through npm. This is is for
+        creating testing bundles that use npm-only dependencies
+
     -h, --help
         Print this message.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,11 +463,10 @@ Options:
     -b, --for-bower
         Use bower.json instead of package.json
 
-   -N, --allow-npm-dev-deps
-   When using --for-bower, this
-        forces packages in the project's package.json#devDependencies to be
-        resolved through npm. This is is for creating testing bundles that use
-        npm-only dependencies
+    -N, --allow-npm-dev-deps
+        When using --for-bower, this forces packages in the project's
+        package.json#devDependencies to be resolved through npm. This is is for
+        creating testing bundles that use npm-only dependencies
 
     -h, --help
         Print this message.

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,26 +431,6 @@ Options:
         Don't emit a bell character for errors that occur while watching.
         Implies --watch.
 
-    -e, --es-syntax
-        Support .mjs files with ECMAScript module syntax:
-
-            import itt from 'itt'
-            export const greeting = 'Hello, world!'
-
-        Instead of CommonJS require syntax:
-
-            const itt = require('itt')
-            exports.greeting = 'Hello, world!'
-
-        .mjs (ESM) files can import .js (CJS) files, in which case the
-        namespace object has a single `default` binding which reflects the
-        value of `module.exports`. CJS files can require ESM files, in which
-        case the resultant object is the namespace object.
-
-    -E, --es-syntax-everywhere
-        Implies --es-syntax. Allow ECMAScript module syntax in .js files.
-        CJS-style `require()` calls are also allowed.
-
     -x, --external <module1,module2,...>
         Don't resolve or include modules named <module1>, <module2>, etc.;
         leave them as require('<module>') references in the bundle. Specifying


### PR DESCRIPTION
I've [fixed the spacing](https://github.com/Financial-Times/scrumple/pull/51/commits/9baf639d4c31604ce8c8d8273fa87ffb2a75363d) on the new option in the `--help` output.
I've also [added it](https://github.com/Financial-Times/scrumple/pull/51/commits/b1b3c778a9dc32bbed9dcb78a9ca8d3cb75a82d9) to the `README.md`, and [removed](https://github.com/Financial-Times/scrumple/pull/51/commits/cb2015addda2c3fb390767e03133458b69b37b99) options from the `--help` output that are no longer used in the code:)