### PR TITLE
Make the scrumple js be es5 syntax to work in ie11 without need a compiler like babel or swc

### DIFF
--- a/src/javascript/head.js
+++ b/src/javascript/head.js
@@ -1,21 +1,21 @@
 (function() {
-  const Scrumple = {}
-  Scrumple.baseRequire = typeof require !== "undefined" ? require : n => {
-    throw new Error(`Could not resolve module name: ${n}`)
+  var Scrumple = {}
+  Scrumple.baseRequire = typeof require !== "undefined" ? require : function(n) {
+    throw new Error("Could not resolve module name: " + n)
   }
-  Scrumple.ignored = () => {}
+  Scrumple.ignored = function(){}
   Scrumple.ignored.deps = {}
   Scrumple.ignored.filename = ''
   Scrumple.modules = {}
   Scrumple.files = {}
   Scrumple.mains = {}
-  Scrumple.resolve = (base, then) => {
+  Scrumple.resolve = function (base, then) {
     base = base.split('/')
     base.shift()
-    for (const p of then.split('/')) {
+    then.split('/').forEach(function(p) {
       if (p === '..') base.pop()
       else if (p !== '.') base.push(p)
-    }
+    })
     return '/' + base.join('/')
   }
   Scrumple.Module = function Module(filename, parent) {
@@ -26,26 +26,26 @@
     this.children = []
     this.exports = {}
   }
-  Scrumple.makeRequire = self => {
-    const require = m => require._module(m).exports
+  Scrumple.makeRequire = function (self) {
+    var require = function(m) { return require._module(m).exports }
     require._deps = {}
     require.main = self
 
-    require._esModule = m => {
-      const mod = require._module(m)
+    require._esModule = function (m) {
+      var mod = require._module(m)
       return mod.exports.__esModule ? mod.exports : {
-        get default() {return mod.exports},
+        get default() {return mod.exports}
       }
     }
-    require._module = m => {
-      let fn = self ? require._deps[m] : Scrumple.main
+    require._module = function (m) {
+      var fn = self ? require._deps[m] : Scrumple.main
       if (fn == null) {
-        const module = {exports: Scrumple.baseRequire(m)}
+        var module = {exports: Scrumple.baseRequire(m)}
         require._deps[m] = {module: module}
         return module
       }
       if (fn.module) return fn.module
-      const module = new Scrumple.Module(fn.filename, self)
+      var module = new Scrumple.Module(fn.filename, self)
       fn.module = module
       module.require = Scrumple.makeRequire(module)
       module.require._deps = fn.deps

--- a/src/test/snapshots/scrumple__test__one-file bundle.snap
+++ b/src/test/snapshots/scrumple__test__one-file bundle.snap
@@ -1,25 +1,25 @@
 ---
 source: src/test/mod.rs
-expression: "std::fs::read_to_string(\"examples/one-file/bumble.js\").unwrap()"
+expression: "std::fs::read_to_string(\"examples/one-file/bumble.js\").unwrap().replace(\"\\r\\n\",\n                                                                        \"\\n\")"
 ---
 (function() {
-  const Scrumple = {}
-  Scrumple.baseRequire = typeof require !== "undefined" ? require : n => {
-    throw new Error(`Could not resolve module name: ${n}`)
+  var Scrumple = {}
+  Scrumple.baseRequire = typeof require !== "undefined" ? require : function(n) {
+    throw new Error("Could not resolve module name: " + n)
   }
-  Scrumple.ignored = () => {}
+  Scrumple.ignored = function(){}
   Scrumple.ignored.deps = {}
   Scrumple.ignored.filename = ''
   Scrumple.modules = {}
   Scrumple.files = {}
   Scrumple.mains = {}
-  Scrumple.resolve = (base, then) => {
+  Scrumple.resolve = function (base, then) {
     base = base.split('/')
     base.shift()
-    for (const p of then.split('/')) {
+    then.split('/').forEach(function(p) {
       if (p === '..') base.pop()
       else if (p !== '.') base.push(p)
-    }
+    })
     return '/' + base.join('/')
   }
   Scrumple.Module = function Module(filename, parent) {
@@ -30,26 +30,26 @@ expression: "std::fs::read_to_string(\"examples/one-file/bumble.js\").unwrap()"
     this.children = []
     this.exports = {}
   }
-  Scrumple.makeRequire = self => {
-    const require = m => require._module(m).exports
+  Scrumple.makeRequire = function (self) {
+    var require = function(m) { return require._module(m).exports }
     require._deps = {}
     require.main = self
 
-    require._esModule = m => {
-      const mod = require._module(m)
+    require._esModule = function (m) {
+      var mod = require._module(m)
       return mod.exports.__esModule ? mod.exports : {
-        get default() {return mod.exports},
+        get default() {return mod.exports}
       }
     }
-    require._module = m => {
-      let fn = self ? require._deps[m] : Scrumple.main
+    require._module = function (m) {
+      var fn = self ? require._deps[m] : Scrumple.main
       if (fn == null) {
-        const module = {exports: Scrumple.baseRequire(m)}
+        var module = {exports: Scrumple.baseRequire(m)}
         require._deps[m] = {module: module}
         return module
       }
       if (fn.module) return fn.module
-      const module = new Scrumple.Module(fn.filename, self)
+      var module = new Scrumple.Module(fn.filename, self)
       fn.module = module
       module.require = Scrumple.makeRequire(module)
       module.require._deps = fn.deps


### PR DESCRIPTION
This should help get our components closer to having their tests run in IE11.
Currently we run `scrumple` to create a bundle and then run `swc` to compile the bundle, however this causes an issue if the code `swc` is compiling contains generators or async functions because then `swc` chucks in a `require('regenerator-runtime')` into the compiled code, which we then need to run through `scrumple` once more to get into the bundle. If scrumple uses modern syntax we then need to pass that final bundle through `swc` one more time to get it to compile to es5 syntax once again.

I couldn't think of a better solution other than having scrumple not use modern syntax.